### PR TITLE
fix reuseNode in shim.js

### DIFF
--- a/Labs/Lab-2.4-Node/analytics/shim.js
+++ b/Labs/Lab-2.4-Node/analytics/shim.js
@@ -7,7 +7,7 @@ require("appdynamics").profile({
   accountAccessKey: process.env.APPDYNAMICS_AGENT_ACCOUNT_ACCESS_KEY, //required
   applicationName: process.env.APPDYNAMICS_AGENT_APPLICATION_NAME,
   tierName: process.env.APPDYNAMICS_AGENT_TIER_NAME, 
-  reuseNode: 'true',
+  reuseNode: true,
   reuseNodePrefix: process.env.APPDYNAMICS_AGENT_NODE_NAME,
   analytics: {
     host: "localhost",

--- a/Labs/Lab-2.4-Node/option-1/shim.js
+++ b/Labs/Lab-2.4-Node/option-1/shim.js
@@ -7,7 +7,7 @@ require("appdynamics").profile({
   accountAccessKey: process.env.APPDYNAMICS_AGENT_ACCOUNT_ACCESS_KEY, //required
   applicationName: process.env.APPDYNAMICS_AGENT_APPLICATION_NAME,
   tierName: process.env.APPDYNAMICS_AGENT_TIER_NAME, 
-  reuseNode: 'true',
+  reuseNode: true,
   reuseNodePrefix: process.env.APPDYNAMICS_AGENT_NODE_NAME
  });
  require(process.env.APP_ENTRY_POINT)

--- a/Labs/Lab-2.4-Node/option-2/shim.js
+++ b/Labs/Lab-2.4-Node/option-2/shim.js
@@ -7,6 +7,6 @@ require("appdynamics").profile({
   accountAccessKey: process.env.APPDYNAMICS_AGENT_ACCOUNT_ACCESS_KEY, //required
   applicationName: process.env.APPDYNAMICS_AGENT_APPLICATION_NAME,
   tierName: process.env.APPDYNAMICS_AGENT_TIER_NAME, 
-  reuseNode: 'true',
+  reuseNode: true,
   reuseNodePrefix: process.env.APPDYNAMICS_AGENT_NODE_NAME
  });

--- a/Labs/Lab-3.1-Node/option-1/shim.js
+++ b/Labs/Lab-3.1-Node/option-1/shim.js
@@ -7,7 +7,7 @@ require("appdynamics").profile({
   accountAccessKey: process.env.APPDYNAMICS_AGENT_ACCOUNT_ACCESS_KEY, //required
   applicationName: process.env.APPDYNAMICS_AGENT_APPLICATION_NAME,
   tierName: process.env.APPDYNAMICS_AGENT_TIER_NAME, 
-  reuseNode: 'true',
-  reuseNodePrefix: process.env.APPDYNAMICS_AGENT_NODE_NAME
+  reuseNode: true,
+  reuseNodePrefix: process.env.APPDYNAMICS_AGENT_NODE_NAME,
  });
  require(process.env.APP_ENTRY_POINT)

--- a/Labs/Lab-3.1-Node/option-2/shim.js
+++ b/Labs/Lab-3.1-Node/option-2/shim.js
@@ -7,7 +7,7 @@ require("appdynamics").profile({
   accountAccessKey: process.env.APPDYNAMICS_AGENT_ACCOUNT_ACCESS_KEY, //required
   applicationName: process.env.APPDYNAMICS_AGENT_APPLICATION_NAME,
   tierName: process.env.APPDYNAMICS_AGENT_TIER_NAME, 
-  reuseNode: 'true',
+  reuseNode: true,
   reuseNodePrefix: process.env.APPDYNAMICS_AGENT_NODE_NAME,
   // analytics: {
   //   host: <analyticsHostName>,

--- a/artifacts/nodejs/openmct/shim.js
+++ b/artifacts/nodejs/openmct/shim.js
@@ -7,7 +7,7 @@ require("appdynamics").profile({
   accountAccessKey: process.env.APPDYNAMICS_AGENT_ACCOUNT_ACCESS_KEY, //required
   applicationName: process.env.APPDYNAMICS_AGENT_APPLICATION_NAME,
   tierName: process.env.APPDYNAMICS_AGENT_TIER_NAME, 
-  reuseNode: 'true',
+  reuseNode: true,
   reuseNodePrefix: process.env.APPDYNAMICS_AGENT_NODE_NAME
  });
 require(process.env.APP_ENTRY_POINT)

--- a/artifacts/nodejs/shim.js
+++ b/artifacts/nodejs/shim.js
@@ -7,7 +7,7 @@ require("appdynamics").profile({
   accountAccessKey: process.env.APPDYNAMICS_AGENT_ACCOUNT_ACCESS_KEY, //required
   applicationName: process.env.APPDYNAMICS_AGENT_APPLICATION_NAME,
   tierName: process.env.APPDYNAMICS_AGENT_TIER_NAME, 
-  reuseNode: 'true',
+  reuseNode: true,
   reuseNodePrefix: process.env.APPDYNAMICS_AGENT_NODE_NAME
  });
 require(process.env.APP_ENTRY_POINT)


### PR DESCRIPTION
AFAIK, `reuseNode: 'true'`  has no effect, so only single node.js node would be visible in controller even if multiple pods are deployed. This PR should fix it since these labs can be used as an example and for reference.. https://docs.appdynamics.com/display/PRO45/Node.js+Settings+Reference